### PR TITLE
[Feat/#43] AccessToken 발급 및 폴더 조회, 정렬, 필터링 api 구현

### DIFF
--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,7 +1,11 @@
-import axiosInstance from "@apis/config/instance";
+import { apiGet } from "@apis/common/methods";
 import { END_POINTS } from "@constants/api";
 
+interface FetchAccessTokenResponse {
+  accessToken: string;
+}
+
 export const fetchAccessToken = async (): Promise<string> => {
-  const response = await axiosInstance.get(END_POINTS.GET_ACCESS_TOKEN);
-  return response.data.accessToken;
+  const { accessToken } = await apiGet<FetchAccessTokenResponse>(END_POINTS.GET_ACCESS_TOKEN);
+  return accessToken;
 };

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,0 +1,7 @@
+import axiosInstance from "@apis/config/instance";
+import { END_POINTS } from "@constants/api";
+
+export const fetchAccessToken = async (): Promise<string> => {
+  const response = await axiosInstance.get(END_POINTS.GET_ACCESS_TOKEN);
+  return response.data.accessToken;
+};

--- a/src/apis/common/methods.ts
+++ b/src/apis/common/methods.ts
@@ -1,0 +1,11 @@
+import axiosInstance from "@apis/config/instance";
+
+export const apiGet = async <T, P = undefined>(url: string, params?: P): Promise<T> => {
+  const response = await axiosInstance.get<T>(url, { params });
+  return response.data;
+};
+
+export const apiPost = async <T, B = undefined>(url: string, body?: B): Promise<T> => {
+  const response = await axiosInstance.post<T>(url, body);
+  return response.data;
+};

--- a/src/apis/config/instance.ts
+++ b/src/apis/config/instance.ts
@@ -8,6 +8,14 @@ const axiosInstance: AxiosInstance = axios.create({
   withCredentials: true,
 });
 
+axiosInstance.interceptors.request.use((config) => {
+  const token = localStorage.getItem("accessToken");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {

--- a/src/apis/folder/folder-queries.ts
+++ b/src/apis/folder/folder-queries.ts
@@ -1,0 +1,15 @@
+import { queryOptions } from "@tanstack/react-query";
+import { fetchFolderList } from "./folder";
+
+export const FOLDER_QUERY_KEY = {
+  ALL: ["folders"],
+  LIST: () => [...FOLDER_QUERY_KEY.ALL, "list"],
+} as const;
+
+export const FOLDER_QUERY_OPTION = {
+  LIST: () =>
+    queryOptions({
+      queryKey: FOLDER_QUERY_KEY.LIST(),
+      queryFn: () => fetchFolderList(),
+    }),
+};

--- a/src/apis/folder/folder-queries.ts
+++ b/src/apis/folder/folder-queries.ts
@@ -1,15 +1,15 @@
 import { queryOptions } from "@tanstack/react-query";
-import { fetchFolderList } from "./folder";
+import { FetchFoldersParams, fetchFolderList } from "./folder";
 
 export const FOLDER_QUERY_KEY = {
   ALL: ["folders"],
-  LIST: () => [...FOLDER_QUERY_KEY.ALL, "list"],
+  LIST: (params?: FetchFoldersParams) => ["folders", "list", params],
 } as const;
 
 export const FOLDER_QUERY_OPTION = {
-  LIST: () =>
+  LIST: (params?: FetchFoldersParams) =>
     queryOptions({
-      queryKey: FOLDER_QUERY_KEY.LIST(),
-      queryFn: () => fetchFolderList(),
+      queryKey: FOLDER_QUERY_KEY.LIST(params),
+      queryFn: () => fetchFolderList(params),
     }),
 };

--- a/src/apis/folder/folder.ts
+++ b/src/apis/folder/folder.ts
@@ -1,4 +1,4 @@
-import axiosInstance from "@apis/config/instance";
+import { apiGet } from "@apis/common/methods";
 import { END_POINTS } from "@constants/api";
 import { FolderListResponse } from "../../types/folder-response";
 
@@ -10,9 +10,6 @@ export interface FetchFoldersParams {
   color?: string;
 }
 
-export const fetchFolderList = async (params?: FetchFoldersParams): Promise<FolderListResponse> => {
-  const response = await axiosInstance.get(END_POINTS.GET_SORT_FILTER, {
-    params,
-  });
-  return response.data;
+export const fetchFolderList = (params?: FetchFoldersParams) => {
+  return apiGet<FolderListResponse, FetchFoldersParams>(END_POINTS.GET_SORT_FILTER, params);
 };

--- a/src/apis/folder/folder.ts
+++ b/src/apis/folder/folder.ts
@@ -1,6 +1,6 @@
 import { apiGet } from "@apis/common/methods";
 import { END_POINTS } from "@constants/api";
-import { FolderListResponse } from "../../types/folder-response";
+import { FolderListResponse } from "@typedefs/folder-response";
 
 export interface FetchFoldersParams {
   parentFolderId?: number;

--- a/src/apis/folder/folder.ts
+++ b/src/apis/folder/folder.ts
@@ -1,0 +1,18 @@
+import axiosInstance from "@apis/config/instance";
+import { END_POINTS } from "@constants/api";
+import { FolderListResponse } from "../../types/folder-response";
+
+export interface FetchFoldersParams {
+  parentFolderId?: number;
+  page?: number;
+  size?: number;
+  order?: string;
+  color?: string;
+}
+
+export const fetchFolderList = async (params?: FetchFoldersParams): Promise<FolderListResponse> => {
+  const response = await axiosInstance.get(END_POINTS.GET_SORT_FILTER, {
+    params,
+  });
+  return response.data;
+};

--- a/src/components/common/dropdown/FolderFilter.stories.tsx
+++ b/src/components/common/dropdown/FolderFilter.stories.tsx
@@ -11,4 +11,5 @@ const Template: StoryFn<typeof FolderFilter> = (args) => <FolderFilter {...args}
 export const Default = Template.bind({});
 Default.args = {
   onSelect: () => {},
+  selected: [],
 };

--- a/src/components/common/dropdown/FolderFilter.tsx
+++ b/src/components/common/dropdown/FolderFilter.tsx
@@ -1,16 +1,21 @@
 import { colorMap } from "@styles/colorMap";
 import { CommonXIcon20, FilteringIcon } from "@svgs/index";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import DropdownButton from "./DropdownContainer";
 import ColorPicker from "./colorPicker/ColorPicker";
 
 interface FolderFilterProps {
   onSelect: (colors: string[]) => void;
+  selected: string[];
 }
 
-const FolderFilter: React.FC<FolderFilterProps> = ({ onSelect }) => {
+const FolderFilter: React.FC<FolderFilterProps> = ({ onSelect, selected }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedColors, setSelectedColors] = useState<string[]>([]);
+
+  useEffect(() => {
+    setSelectedColors(selected);
+  }, [selected]);
 
   const handleColorSelect = (colors: string[]) => {
     setSelectedColors(colors);

--- a/src/components/common/dropdown/Sort.tsx
+++ b/src/components/common/dropdown/Sort.tsx
@@ -1,27 +1,38 @@
 import { Text } from "@components/typography/Text";
 import { SortIcon } from "@svgs/index";
-import { handleSelect } from "@utils/dropdownHandlers";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import DropdownButton from "./DropdownContainer";
 
 interface SortProps {
   onSelect: (value: string) => void;
+  selected: string;
 }
 
-const Sort: React.FC<SortProps> = ({ onSelect }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedSort, setSelectedSort] = useState("최근 수정일 순");
+const sortOptions = [
+  { label: "가나다 순", value: "asc" },
+  { label: "가나다 역순", value: "desc" },
+  { label: "최근 수정일 순", value: "edit-newest" },
+  { label: "최근 생성일 순", value: "edit-oldest" },
+];
 
-  const sortOptions = [
-    { label: "가나다 순", value: "asc" },
-    { label: "가나다 역순", value: "desc" },
-    { label: "최근 수정일 순", value: "recentEdit" },
-    { label: "최근 생성일 순", value: "recentCreate" },
-  ];
+const Sort: React.FC<SortProps> = ({ onSelect, selected }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedLabel, setSelectedLabel] = useState("최근 수정일 순");
+
+  useEffect(() => {
+    const matched = sortOptions.find((option) => option.value === selected);
+    if (matched) setSelectedLabel(matched.label);
+  }, [selected]);
+
+  const handleSelect = (value: string, label: string) => {
+    onSelect(value);
+    setSelectedLabel(label);
+    setIsOpen(false);
+  };
 
   return (
     <DropdownButton
-      label={selectedSort}
+      label={selectedLabel}
       icon={<SortIcon width={20} height={20} />}
       isOpen={isOpen}
       setIsOpen={setIsOpen}
@@ -32,7 +43,7 @@ const Sort: React.FC<SortProps> = ({ onSelect }) => {
           role="button"
           tabIndex={0}
           className="px-5 py-4 text-base-black hover:bg-gray-50 cursor-pointer border-b border-gray-150 whitespace-nowrap"
-          onClick={() => handleSelect(option.value, option.label, setSelectedSort, onSelect, setIsOpen)}
+          onClick={() => handleSelect(option.value, option.label)}
         >
           <Text variant="sub_heading3">{option.label}</Text>
         </div>

--- a/src/components/common/dropdown/Sort.tsx
+++ b/src/components/common/dropdown/Sort.tsx
@@ -39,6 +39,7 @@ const Sort: React.FC<SortProps> = ({ onSelect, selected }) => {
     >
       {sortOptions.map((option) => (
         <button
+          key={option.value}
           type="button"
           onClick={() => handleSelect(option.value, option.label)}
           className="w-full text-left px-5 py-4 text-base-black hover:bg-gray-50 cursor-pointer border-b border-gray-150 whitespace-nowrap appearance-none bg-transparent"

--- a/src/components/common/dropdown/Sort.tsx
+++ b/src/components/common/dropdown/Sort.tsx
@@ -38,15 +38,15 @@ const Sort: React.FC<SortProps> = ({ onSelect, selected }) => {
       setIsOpen={setIsOpen}
     >
       {sortOptions.map((option) => (
-        <div
-          key={option.value}
-          role="button"
-          tabIndex={0}
-          className="px-5 py-4 text-base-black hover:bg-gray-50 cursor-pointer border-b border-gray-150 whitespace-nowrap"
+        <button
+          type="button"
           onClick={() => handleSelect(option.value, option.label)}
+          className="w-full text-left px-5 py-4 text-base-black hover:bg-gray-50 cursor-pointer border-b border-gray-150 whitespace-nowrap appearance-none bg-transparent"
         >
-          <Text variant="sub_heading3">{option.label}</Text>
-        </div>
+          <Text variant="sub_heading3" className="block w-full">
+            {option.label}
+          </Text>
+        </button>
       ))}
     </DropdownButton>
   );

--- a/src/components/common/dropdown/Sort.tsx
+++ b/src/components/common/dropdown/Sort.tsx
@@ -27,16 +27,15 @@ const Sort: React.FC<SortProps> = ({ onSelect }) => {
       setIsOpen={setIsOpen}
     >
       {sortOptions.map((option) => (
-        <button
+        <div
           key={option.value}
+          role="button"
           tabIndex={0}
           className="px-5 py-4 text-base-black hover:bg-gray-50 cursor-pointer border-b border-gray-150 whitespace-nowrap"
-          onClick={
-            () => handleSelect(option.value, option.label, setSelectedSort, onSelect, setIsOpen) // ✅ handleSelect 호출
-          }
+          onClick={() => handleSelect(option.value, option.label, setSelectedSort, onSelect, setIsOpen)}
         >
           <Text variant="sub_heading3">{option.label}</Text>
-        </button>
+        </div>
       ))}
     </DropdownButton>
   );

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,3 +1,4 @@
 export const END_POINTS = {
   GET_ACCESS_TOKEN: "/api/v1/auth/token",
+  GET_SORT_FILTER: "/api/v1/folders/sort-filter",
 };

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,3 @@
+export const END_POINTS = {
+  GET_ACCESS_TOKEN: "/api/v1/auth/token",
+};

--- a/src/mocks/FolderItemData.ts
+++ b/src/mocks/FolderItemData.ts
@@ -1,7 +1,7 @@
 import { colorMap } from "@styles/colorMap";
 
 interface FolderItemDataProps {
-  folderId: number;
+  id: number;
   folderName: string;
   createdAt: string;
   noteCount: number;
@@ -11,7 +11,7 @@ interface FolderItemDataProps {
 
 const FolderItemData: FolderItemDataProps[] = [
   {
-    folderId: 1,
+    id: 1,
     folderName: "포근한 핫팩",
     createdAt: "24/08/20",
     noteCount: 10,
@@ -19,7 +19,7 @@ const FolderItemData: FolderItemDataProps[] = [
     markState: false,
   },
   {
-    folderId: 2,
+    id: 2,
     folderName: "휴먼미디어인터랙션디자인개론",
     createdAt: "24/08/20",
     noteCount: 100,
@@ -27,7 +27,7 @@ const FolderItemData: FolderItemDataProps[] = [
     markState: true,
   },
   {
-    folderId: 3,
+    id: 3,
     folderName: "웹 디자인 잘하는 방법",
     createdAt: "24/08/20",
     noteCount: 100,
@@ -39,7 +39,7 @@ const FolderItemData: FolderItemDataProps[] = [
 // 80번까지 데이터 추가
 for (let i = 4; i <= 100; i++) {
   FolderItemData.push({
-    folderId: i,
+    id: i,
     folderName: `폴더 ${i}`,
     createdAt: `24/08/${String(10 + (i % 20)).padStart(2, "0")}`,
     noteCount: Math.floor(Math.random() * 120),

--- a/src/pages/archive/components/MainFolderItem/MainFolderItem.tsx
+++ b/src/pages/archive/components/MainFolderItem/MainFolderItem.tsx
@@ -1,21 +1,19 @@
 import Kebab from "@components/common/dropdown/Kebab";
 import { Text } from "@components/typography/Text";
-import { colorMap } from "@styles/colorMap";
 import { ArchiveNoteIcon, EmptyStarIcon } from "@svgs/index";
+import { getSafeColor } from "@utils/color";
 import { useState } from "react";
 import { StarIcon } from "../StarIcon";
 import { DeleteFolderModal } from "../modal/DeleteFolderModal/DeleteFolderModal";
 import { EditFolderModal } from "../modal/EditFolderModal/EditFolderModal";
 import { ArchiveMainFolderIcon } from "./ArchiveMainFolderIcon";
 
-type Color = keyof typeof colorMap;
-
 interface MainFolderItemProps {
   id: number;
   folderName: string;
   createdAt: string;
   noteCount: number;
-  folderColor: Color;
+  folderColor: string;
   markState?: boolean;
   variant?: "home" | "archive";
 }
@@ -33,18 +31,16 @@ const MainFolderItem: React.FC<MainFolderItemProps> = ({
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const handleEditFolder = () => {
-    setIsEditModalOpen(false);
-  };
 
-  const handleDeleteFolder = () => {
-    setIsDeleteModalOpen(false);
-  };
+  const handleEditFolder = () => setIsEditModalOpen(false);
+  const handleDeleteFolder = () => setIsDeleteModalOpen(false);
+
+  const fillColor = getSafeColor(folderColor);
 
   return (
     <div className="flex flex-col relative w-[11.75rem] h-[11.75rem] p-6 pb-4 bg-white rounded-lg border border-gray-150 hover:bg-brand-20 cursor-pointer">
       <div className="relative w-[3.75rem] h-[3.75rem] flex-shrink-0">
-        <ArchiveMainFolderIcon fillColor={colorMap[folderColor]} />
+        <ArchiveMainFolderIcon fillColor={fillColor} />
 
         {markState ? (
           <div className="absolute top-8 right-[0.37rem] w-4 h-4">
@@ -59,12 +55,8 @@ const MainFolderItem: React.FC<MainFolderItemProps> = ({
         <div className="absolute top-6 right-4 cursor-pointer z-10">
           <Kebab
             onSelect={(value) => {
-              if (value === "edit") {
-                setIsEditModalOpen(true);
-              }
-              if (value === "delete") {
-                setIsDeleteModalOpen(true);
-              }
+              if (value === "edit") setIsEditModalOpen(true);
+              if (value === "delete") setIsDeleteModalOpen(true);
             }}
           />
         </div>

--- a/src/pages/archive/components/MainFolderList/MainFolderList.tsx
+++ b/src/pages/archive/components/MainFolderList/MainFolderList.tsx
@@ -1,19 +1,17 @@
 import Pagination from "@components/common/pagination/Pagination";
 import { Text } from "@components/typography/Text";
 import EmptyState from "@pages/home/components/EmptyState/EmptyState";
-import { colorMap } from "@styles/colorMap";
 import { useState } from "react";
 import FolderItemData from "src/mocks/FolderItemData";
 import MainFolderItem from "../MainFolderItem/MainFolderItem";
 import NewFolderMain from "../newFolder/NewFolderMain";
 
-type Color = keyof typeof colorMap;
-interface MainFolderProps {
+export interface MainFolderProps {
   id: number;
   folderName: string;
   createdAt: string;
   noteCount: number;
-  folderColor: Color;
+  folderColor: string;
   markState?: boolean;
 }
 

--- a/src/pages/archive/components/NoteItem/NoteItem.tsx
+++ b/src/pages/archive/components/NoteItem/NoteItem.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@components/typography/Text";
 import { ArchiveNoteIcon, CheckboxIcon, FlashcardIcon, StarIcon } from "@svgs/index";
-import { NoteItemProps } from "../../types/note";
+import { NoteItemProps } from "@typedefs/note";
 
 const NoteItem: React.FC<NoteItemProps> = ({ name, createdAt, editDate, flashCardCount, folderColor }) => {
   const displayFlashcardNum = flashCardCount > 99 ? "99+" : flashCardCount;

--- a/src/pages/archive/components/modal/EditFolderModal/EditFolderModal.tsx
+++ b/src/pages/archive/components/modal/EditFolderModal/EditFolderModal.tsx
@@ -2,6 +2,7 @@ import { Text } from "@components/typography/Text";
 import { useColorUtils } from "@pages/archive/hooks/useColorUtils";
 import { colorMap } from "@styles/colorMap";
 import { ColorCircleCheckIcon, ColorCircleIcon } from "@svgs/index";
+import { isValidColor } from "@utils/color";
 import React, { useState, useRef } from "react";
 import { ArchiveFolderIcon } from "../../ArchiveFolderIcon";
 
@@ -9,8 +10,8 @@ interface EditFolderModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (folderName: string, folderColor: string) => void;
-  folderName: string; // 기존 폴더 이름
-  folderColor: keyof typeof colorMap; // 기존 폴더 색상
+  folderName: string;
+  folderColor: string;
 }
 
 export const EditFolderModal: React.FC<EditFolderModalProps> = ({
@@ -20,11 +21,14 @@ export const EditFolderModal: React.FC<EditFolderModalProps> = ({
   folderName,
   folderColor,
 }) => {
-  const [editedFolderName, setEditedFolderName] = useState(folderName);
-  const [selectedColor, setSelectedColor] = useState(folderColor);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-
   const { darkenColor } = useColorUtils();
+
+  const [editedFolderName, setEditedFolderName] = useState(folderName);
+
+  const [selectedColor, setSelectedColor] = useState<keyof typeof colorMap>(
+    isValidColor(folderColor) ? folderColor : "gray",
+  );
 
   const handleSubmit = () => {
     if (editedFolderName.trim()) {
@@ -80,7 +84,7 @@ export const EditFolderModal: React.FC<EditFolderModalProps> = ({
           </Text>
         </div>
 
-        {/* Color Picker + Icon */}
+        {/* Color Picker */}
         <Text variant="sub_heading3" className="block text-gray-700 mb-[1.06rem]">
           색상
         </Text>
@@ -105,6 +109,7 @@ export const EditFolderModal: React.FC<EditFolderModalProps> = ({
           </div>
 
           <div className="w-[0.0625rem] h-full bg-gray-300 ml-[3.75rem] mr-12"></div>
+
           <div className="w-[2.5rem] h-[2.5rem]">
             <ArchiveFolderIcon
               fillColor={colorMap[selectedColor]}

--- a/src/pages/archive/hooks/use-folder-list.ts
+++ b/src/pages/archive/hooks/use-folder-list.ts
@@ -1,0 +1,12 @@
+import { FOLDER_QUERY_OPTION } from "@apis/folder/folder-queries";
+import { useQuery } from "@tanstack/react-query";
+
+export const useFolderList = () => {
+  const { data, isLoading, isError } = useQuery(FOLDER_QUERY_OPTION.LIST());
+
+  return {
+    foldersList: data?.foldersList ?? [],
+    isLoading,
+    isError,
+  };
+};

--- a/src/pages/archive/hooks/use-folder-list.ts
+++ b/src/pages/archive/hooks/use-folder-list.ts
@@ -1,8 +1,9 @@
+import { FetchFoldersParams } from "@apis/folder/folder";
 import { FOLDER_QUERY_OPTION } from "@apis/folder/folder-queries";
 import { useQuery } from "@tanstack/react-query";
 
-export const useFolderList = () => {
-  const { data, isLoading, isError } = useQuery(FOLDER_QUERY_OPTION.LIST());
+export const useFolderList = (params?: FetchFoldersParams) => {
+  const { data, isLoading, isError } = useQuery(FOLDER_QUERY_OPTION.LIST(params));
 
   return {
     foldersList: data?.foldersList ?? [],

--- a/src/pages/archive/pages/index.stories.tsx
+++ b/src/pages/archive/pages/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from "@storybook/react";
-import { Archive } from "./index";
+import Archive from "./index";
 
 export default {
   title: "Archive/pages/Archive",

--- a/src/pages/archive/pages/index.stories.tsx
+++ b/src/pages/archive/pages/index.stories.tsx
@@ -1,12 +1,19 @@
 import { Meta, StoryFn } from "@storybook/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Archive from "./index";
+
+const queryClient = new QueryClient();
 
 export default {
   title: "Archive/pages/Archive",
   component: Archive,
 } as Meta<typeof Archive>;
 
-const Template: StoryFn<typeof Archive> = () => <Archive />;
+const Template: StoryFn<typeof Archive> = () => (
+  <QueryClientProvider client={queryClient}>
+    <Archive />
+  </QueryClientProvider>
+);
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/src/pages/archive/pages/index.tsx
+++ b/src/pages/archive/pages/index.tsx
@@ -3,10 +3,11 @@ import Sort from "@components/common/dropdown/Sort";
 import { Text } from "@components/typography/Text";
 import { mapToMainFolderProps } from "@utils/folder-mapper";
 import { useState } from "react";
+import EmptyState from "../components/EmptyState/EmptyState";
 import MainFolderList from "../components/MainFolderList/MainFolderList";
 import { useFolderList } from "../hooks/use-folder-list";
 
-export const Archive = () => {
+const Archive = () => {
   const [order, setOrder] = useState("edit-newest");
   const [colors, setColors] = useState<string[]>([]);
 
@@ -32,9 +33,17 @@ export const Archive = () => {
         </div>
 
         <div className="flex mt-8">
-          <MainFolderList folders={transformedFolders} variant="archive" />
+          {transformedFolders.length === 0 ? (
+            <div className="mt-12 w-full flex justify-center">
+              <EmptyState type="folder" />
+            </div>
+          ) : (
+            <MainFolderList folders={transformedFolders} variant="archive" />
+          )}
         </div>
       </div>
     </div>
   );
 };
+
+export default Archive;

--- a/src/pages/archive/pages/index.tsx
+++ b/src/pages/archive/pages/index.tsx
@@ -2,29 +2,24 @@ import FolderFilter from "@components/common/dropdown/FolderFilter";
 import Sort from "@components/common/dropdown/Sort";
 import { Text } from "@components/typography/Text";
 import { mapToMainFolderProps } from "@utils/folder-mapper";
+import { useState } from "react";
 import MainFolderList from "../components/MainFolderList/MainFolderList";
 import { useFolderList } from "../hooks/use-folder-list";
 
-const handleSortSelect = (value: string) => {
-  console.log("Sort selected:", value);
-};
-
-const handleFolderFilterSelect = (colors: string[]) => {
-  console.log("Filter selected:", colors);
-};
-
 export const Archive = () => {
-  const { foldersList, isLoading, isError } = useFolderList();
+  const [order, setOrder] = useState("edit-newest");
+  const [colors, setColors] = useState<string[]>([]);
 
-  if (isLoading) {
-    return <div>로딩 중...</div>;
-  }
-
-  if (isError) {
-    return <div>에러가 발생했습니다</div>;
-  }
+  const { foldersList, isLoading, isError } = useFolderList({
+    order,
+    color: colors.join(","),
+  });
 
   const transformedFolders = foldersList.map(mapToMainFolderProps);
+
+  //TODO: 로딩 ui 받으면 suspense로 수정 및 에러도 에러바운더리로 리팩토링 예정
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>에러가 발생했습니다</div>;
 
   return (
     <div className="w-full flex justify-center">
@@ -32,8 +27,8 @@ export const Archive = () => {
         <Text variant="heading2">사용자의 아카이브</Text>
 
         <div className="mt-10 flex gap-2 z-10">
-          <Sort onSelect={handleSortSelect} />
-          <FolderFilter onSelect={handleFolderFilterSelect} />
+          <Sort selected={order} onSelect={setOrder} />
+          <FolderFilter selected={colors} onSelect={setColors} />
         </div>
 
         <div className="flex mt-8">

--- a/src/pages/archive/pages/index.tsx
+++ b/src/pages/archive/pages/index.tsx
@@ -1,7 +1,9 @@
 import FolderFilter from "@components/common/dropdown/FolderFilter";
 import Sort from "@components/common/dropdown/Sort";
 import { Text } from "@components/typography/Text";
+import { mapToMainFolderProps } from "@utils/folder-mapper";
 import MainFolderList from "../components/MainFolderList/MainFolderList";
+import { useFolderList } from "../hooks/use-folder-list";
 
 const handleSortSelect = (value: string) => {
   console.log("Sort selected:", value);
@@ -12,20 +14,30 @@ const handleFolderFilterSelect = (colors: string[]) => {
 };
 
 export const Archive = () => {
+  const { foldersList, isLoading, isError } = useFolderList();
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (isError) {
+    return <div>에러가 발생했습니다</div>;
+  }
+
+  const transformedFolders = foldersList.map(mapToMainFolderProps);
+
   return (
     <div className="w-full flex justify-center">
       <div className="w-[50rem] mt-10 flex flex-col">
-        <Text variant={"heading2"}>사용자의 아카이브</Text>
+        <Text variant="heading2">사용자의 아카이브</Text>
 
-        {/* SortDropdown + FolderFilterDropdown */}
         <div className="mt-10 flex gap-2 z-10">
           <Sort onSelect={handleSortSelect} />
           <FolderFilter onSelect={handleFolderFilterSelect} />
         </div>
 
-        {/* FolderList */}
         <div className="flex mt-8">
-          <MainFolderList />
+          <MainFolderList folders={transformedFolders} variant="archive" />
         </div>
       </div>
     </div>

--- a/src/pages/flashcard/index.tsx
+++ b/src/pages/flashcard/index.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-
-export const Flashcard = () => {
+const Flashcard = () => {
   return <></>;
 };
+
+export default Flashcard;

--- a/src/pages/home/components/RecentMarkedNote/RecentMarkedNoteItem.tsx
+++ b/src/pages/home/components/RecentMarkedNote/RecentMarkedNoteItem.tsx
@@ -1,7 +1,6 @@
 import { Text } from "@components/typography/Text";
 import { ArchiveNoteIcon, FlashcardIcon, StarIcon } from "@svgs/index";
-import React from "react";
-import { NoteItemProps } from "../../../../types/note";
+import { NoteItemProps } from "@typedefs/note";
 
 const RecentMarkedNoteItem: React.FC<NoteItemProps> = ({ name, content, folderColor, editDate, flashCardCount }) => {
   const displayFlashcardNum = flashCardCount > 99 ? "99+" : flashCardCount;

--- a/src/pages/home/components/RecentMarkedNote/RecentMarkedNoteList.tsx
+++ b/src/pages/home/components/RecentMarkedNote/RecentMarkedNoteList.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { NoteItemProps } from "../../../../types/note";
+import { NoteItemProps } from "@typedefs/note";
 import EmptyState from "../EmptyState/EmptyState";
 import RecentMarkedNoteItem from "./RecentMarkedNoteItem";
 

--- a/src/pages/home/components/ScheduledLearning/ScheduledLearningItem.tsx
+++ b/src/pages/home/components/ScheduledLearning/ScheduledLearningItem.tsx
@@ -1,7 +1,6 @@
 import { Text } from "@components/typography/Text";
 import { HomeFlashcardIcon } from "@svgs/index";
-import React from "react";
-import { ScheduledLearningItemProps } from "../../../../types/scheduledLearning";
+import { ScheduledLearningItemProps } from "@typedefs/scheduledLearning";
 
 const ScheduledLearningItem: React.FC<ScheduledLearningItemProps> = ({
   name,

--- a/src/pages/home/components/ScheduledLearning/ScheduledLearningList.tsx
+++ b/src/pages/home/components/ScheduledLearning/ScheduledLearningList.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { ScheduledLearningItemProps } from "../../../../types/scheduledLearning";
+import { ScheduledLearningItemProps } from "@typedefs/scheduledLearning";
 import EmptyState from "../EmptyState/EmptyState";
 import ScheduledLearningItem from "./ScheduledLearningItem";
 

--- a/src/pages/home/index.stories.tsx
+++ b/src/pages/home/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryFn } from "@storybook/react";
 import { BrowserRouter } from "react-router-dom";
-import { Home } from "./index";
+import Home from "./index";
 
 export default {
   title: "Home/Pages/HomePage",

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -6,7 +6,7 @@ import { requestAccessTokenOnce } from "@utils/access-token";
 import RecentMarkedNoteList from "./components/RecentMarkedNote/RecentMarkedNoteList";
 import ScheduledLearningList from "./components/ScheduledLearning/ScheduledLearningList";
 
-export const Home = () => {
+const Home = () => {
   requestAccessTokenOnce();
 
   return (
@@ -32,3 +32,5 @@ export const Home = () => {
     </div>
   );
 };
+
+export default Home;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -2,11 +2,13 @@ import { Text } from "@components/typography/Text";
 import { mockRecentMarkedNotes } from "@mocks/MockRecentMarkedNotes";
 import { mockScheduledLearningItems } from "@mocks/MockScheduledLearningItems";
 import MainFolderList from "@pages/archive/components/MainFolderList/MainFolderList";
-import React from "react";
+import { requestAccessTokenOnce } from "@utils/access-token";
 import RecentMarkedNoteList from "./components/RecentMarkedNote/RecentMarkedNoteList";
 import ScheduledLearningList from "./components/ScheduledLearning/ScheduledLearningList";
 
 export const Home = () => {
+  requestAccessTokenOnce();
+
   return (
     <div className="w-[800px] mx-auto pb-20 text-base-black">
       <Text variant={"heading2"} className="mt-10">

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,6 +1,6 @@
-export { Home } from "./home";
+export { default as Home } from "./home";
 export { default as Archive } from "./archive/pages";
-export { Flashcard } from "./flashcard";
-export { Library } from "./library";
-export { Mypage } from "./mypage";
-export { LoginPage } from "./login";
+export { default as Flashcard } from "./flashcard";
+export { default as Library } from "./library";
+export { default as Mypage } from "./mypage";
+export { default as LoginPage } from "./login";

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,5 @@
 export { Home } from "./home";
-export { Archive } from "./archive/pages";
+export { default as Archive } from "./archive/pages";
 export { Flashcard } from "./flashcard";
 export { Library } from "./library";
 export { Mypage } from "./mypage";

--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-
-export const Library = () => {
+const Library = () => {
   return <></>;
 };
+
+export default Library;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,5 +1,7 @@
 import Login from "./pages/Login";
 
-export const LoginPage = () => {
+const LoginPage = () => {
   return <Login />;
 };
+
+export default LoginPage;

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-
-export const Mypage = () => {
+const Mypage = () => {
   return <></>;
 };
+
+export default Mypage;

--- a/src/types/folder-response.ts
+++ b/src/types/folder-response.ts
@@ -1,0 +1,20 @@
+export interface FolderItem {
+  folderId: number;
+  name: string;
+  color: string;
+  markState: "INACTIVE" | "ACTIVE";
+  getNoteCount: number;
+  markDate: string;
+  editDate: string;
+  createdAt: string;
+}
+
+export interface FolderListResponse {
+  foldersList: FolderItem[];
+  listSize: number;
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  isFirst: boolean;
+  isLast: boolean;
+}

--- a/src/types/folder.ts
+++ b/src/types/folder.ts
@@ -1,12 +1,8 @@
-import { colorMap } from "@styles/colorMap";
-
-type Color = keyof typeof colorMap;
-
 export interface MainFolderItemProps {
   folderId: number;
   folderName: string;
   createdAt: string;
   noteCount: number;
-  folderColor: Color;
+  folderColor: string;
   markState?: boolean;
 }

--- a/src/utils/access-token.ts
+++ b/src/utils/access-token.ts
@@ -1,0 +1,16 @@
+import { fetchAccessToken } from "@apis/auth/auth";
+
+let hasFetchedAccessToken = false;
+
+export const requestAccessTokenOnce = async () => {
+  if (hasFetchedAccessToken || localStorage.getItem("accessToken")) return;
+
+  hasFetchedAccessToken = true;
+
+  try {
+    const token = await fetchAccessToken();
+    localStorage.setItem("accessToken", token);
+  } catch (error) {
+    console.error("accessToken 요청 실패:", error);
+  }
+};

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,9 @@
+import { colorMap } from "@styles/colorMap";
+
+export function isValidColor(color: string): color is keyof typeof colorMap {
+  return color in colorMap;
+}
+
+export function getSafeColor(color: string): string {
+  return isValidColor(color) ? colorMap[color] : "#D9D9D9";
+}

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -5,5 +5,5 @@ export function isValidColor(color: string): color is keyof typeof colorMap {
 }
 
 export function getSafeColor(color: string): string {
-  return isValidColor(color) ? colorMap[color] : "#D9D9D9";
+  return isValidColor(color) ? colorMap[color] : colorMap["gray"];
 }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -5,5 +5,5 @@ export function isValidColor(color: string): color is keyof typeof colorMap {
 }
 
 export function getSafeColor(color: string): string {
-  return isValidColor(color) ? colorMap[color] : colorMap["gray"];
+  return isValidColor(color) ? colorMap[color] : colorMap.gray;
 }

--- a/src/utils/folder-mapper.ts
+++ b/src/utils/folder-mapper.ts
@@ -1,5 +1,5 @@
 import { MainFolderProps } from "@pages/archive/components/MainFolderList/MainFolderList";
-import { FolderItem } from "../types/folder-response";
+import { FolderItem } from "@typedefs/folder-response";
 
 export const mapToMainFolderProps = (folder: FolderItem): MainFolderProps => {
   return {

--- a/src/utils/folder-mapper.ts
+++ b/src/utils/folder-mapper.ts
@@ -1,0 +1,13 @@
+import { MainFolderProps } from "@pages/archive/components/MainFolderList/MainFolderList";
+import { FolderItem } from "../types/folder-response";
+
+export const mapToMainFolderProps = (folder: FolderItem): MainFolderProps => {
+  return {
+    id: folder.folderId,
+    folderName: folder.name,
+    createdAt: folder.createdAt,
+    noteCount: folder.getNoteCount,
+    folderColor: folder.color,
+    markState: folder.markState === "ACTIVE",
+  };
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -30,7 +30,7 @@
       "@styles/*": ["src/styles/*"],
       "@utils/*": ["src/utils/*"],
       "@apis/*": ["src/apis/*"],
-      "@types/*": ["src/types/*"],
+      "@typedefs/*": ["src/types/*"],
       "@routes/*": ["src/routes/*"],
       "@mocks/*": ["src/mocks/*"],
       "@constants/*": ["src/constants/*"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -32,7 +32,8 @@
       "@apis/*": ["src/apis/*"],
       "@types/*": ["src/types/*"],
       "@routes/*": ["src/routes/*"],
-      "@mocks/*": ["src/mocks/*"]
+      "@mocks/*": ["src/mocks/*"],
+      "@constants/*": ["src/constants/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) [feat/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- close #43 

## 🔑 주요 변경사항
<!-- 내가 작업한 내용에 대해 작성해주세요 -->
- 액세스토큰 받아오는 api 연결
- 폴더 조회, 정렬, 필터링 api 연결

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📸 스크린샷 or 실행영상
https://github.com/user-attachments/assets/467663d8-aa19-44c9-a780-31c04c421db9

날짜 형식은 서버한테 맞춰달라고 요청해놓았습니다. 물론 제가 매핑해도 되지만 서버가 응답 구조 자체를 수정하는 게 더 안정적일 것 같아서요. ui 무너진 건 무시하세요... 그리고 중간중간 짧게 로딩이라고 뜨는 건 코드 파일에도 to do 주석 달아놓았지만 로딩 ui 받은 후 서스펜스 처리하는 걸로 리팩토링 할 겁니다 ,,, 임시로 해둔 거임 근데 스켈레톤으로 구현해도 괜찮을 거 같기도 하고?

**폴더 없을 때**
![스크린샷 2025-03-25 오전 2 53 50](https://github.com/user-attachments/assets/22a603d8-5a46-499d-b647-da95e8f946b6)


## 📢 To Reviewers
에러 백만개 해결하느라 늦어졌네요 ^^... 이제 api 연결 레전드 잘 되니까 기계 마냥 api 붙여봅시다 ~~

#### 1. 액세스 토큰 관련
기존에는 서버가 쿠키에 액세스토큰을 담아주는 구조였는데 스웨거 보면 알 수 있다시피 현재 api 설계가 authorization 헤더를 필수로 요구하는 형태였던 터라 충돌이 생겼었어요. 저희는 쿠키에서 토큰을 빼서 쓰지 못하기 때문에... 그래서 이제는 소셜 로그인을 하고 난 이후에 리다이렉트 되는 페이지 즉, /home에서` api/v1/auth/token` api를 통해 액세스 토큰을 받아오고 로컬 스토리지에 저장해놓는 기능을 구현해놓았습니다. 이를 유틸로 분리해놓은 이유는 확장성을 고려해 분리해뒀어요.

#### 2. types 경로 관련
현재 types 절대 경로가 안 먹던데 저만 그런가요? 우선 상대 경로로 작성해두었습니다~
-> @types는 typescript가 이미 다른 예약어로 사용 중이라 그렇대요 논의 ㄱㄱ
@typedefs 쓰기로함

#### 3. export 방식 통일
보니까 페이지 컴포넌트는 `export` 방식이 다르던데 통일하는 게 좋을 거 같아서 `default export`로 변경해두었습니다. 

#### 4. 폴더 컬러 타입 처리 방식 통일
기존에는 `folderColor: keyof typeof colorMap` 형태로 타입을 제한했었는데, 서버에서 오는 값은 그냥 string이라 타입 에러가 계속 발생했어요. 그래서 지금은 아래와 같은 방식으로 처리하도록 수정했습니다. 혹시 `folderColor`를 사용하는 다른 컴포넌트를 구현하신다면 참고해주세요!
```
`folderColor`는 `string`으로 받고, 색상 렌더링 시 `getSafeColor(color)` 유틸을 사용해 유효한 색상만 `colorMap`에서 매핑
 아니라면 `fallback color (gray)` 사용
```